### PR TITLE
Update scoringAlgorithms test to match book instructions

### DIFF
--- a/test/scrabble-scorer.test.js
+++ b/test/scrabble-scorer.test.js
@@ -133,13 +133,13 @@ describe("Scrabble Scorer solution", function() {
 
 	it("scoringAlgorithms contain three scoring objects", function() {
 		expect(solution.scoringAlgorithms[0]).toEqual(expect.objectContaining({
-			scorerFunction: solution.simpleScorer
+			scoringFunction: solution.simpleScorer
 		}));
 		expect(solution.scoringAlgorithms[1]).toEqual(expect.objectContaining({
-			scorerFunction: solution.vowelBonusScorer
+			scoringFunction: solution.vowelBonusScorer
 		}));
 		expect(solution.scoringAlgorithms[2]).toEqual(expect.objectContaining({
-			scorerFunction: solution.scrabbleScorer
+			scoringFunction: solution.scrabbleScorer
 		}));
 	});
 	


### PR DESCRIPTION
The book specifies `scoringFunction` as the object key rather than `scorerFunction`. [See Task 2 Instructions here.](https://education.launchcode.org/intro-to-web-dev-curriculum/assignments/scrabble-scorer/scoring-algorithms/index.html)

Would resolve #6 